### PR TITLE
Omniauth environment variables

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,7 +1,21 @@
+# Login: https://apis.io/auth/github (redirects to GitHub)
+# Callback URL: http://apis.io/auth/github/callback
+#
+# For development change `apis.io` to `localhost:3000`.
+#
+# The environment variables need to be set. To set them locally:
+#
+#     export GITHUB_CLIENT_ID=<client-id>
+#     export GITHUB_CLIENT_SECRET=<client-secret>
+#
+# To set them on Heroku:
+#
+#     heroku config:add GITHUB_CLIENT_ID=<client-id> GITHUB_CLIENT_SECRET=<client-secret>
+#
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :github, '6606ca9f6a7be1dc45b6', '9b663eea83e4fc1e434c95bd2a4c874ce5a9f9c8'
+  envvars = {id: 'GITHUB_CLIENT_ID', secret: 'GITHUB_CLIENT_SECRET'}
+  envvars.values.each do |envvar|
+    raise "The #{envvar} environment variable must be set." unless ENV.has_key? envvar
+  end
+  provider :github, ENV[envvars[:id]], ENV[envvars[:secret]]
 end
-
-
-# /auth/github
-# http://apis.io/auth/github/callback


### PR DESCRIPTION
To log into my local dev instance I needed to change the GitHub OAuth Application used so it would redirect to my local dev instance. I saw that they're hardcoded in `config/initializers/omniauth.rb`. Besides having to change the contents of the repo to override it, this makes the keys public. This is OK in this case, it seems, because to get a token it needs to redirect to apis.io, but this takes a moment to realize. It's more proper if they're private.

For things to be private on heroku the most common way is environment variables. I'm using them locally, too. I run `source ~/dotfiles/config/apisio` which has my GitHub application `apisio-benatkin-dev` which redirects to `localhost:3000`. I find this works pretty well. I can also put these in `.rvmrc` which I don't commit.

In order to use this change you'll need to:
- delete the [GitHub OAuth App](https://github.com/settings/applications) and create a new one since the key's been exposed to the public
- run `heroku config` as in [the updated omniauth.rb](https://github.com/benatkin/apisio/blob/omniauth-environment-variables/config/initializers/omniauth.rb)
- push up the new code

Cheers!

Ben
